### PR TITLE
Add support for flushing/clearing all items

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ pip3 install -r requirements.txt
 `python3 src/main.py <memcache-host> <memcache-port>`
 
 - <kbd>r</kbd>: refresh key list
+- <kbd>f</kbd>: flush/clear key list
 - <kbd>enter</kbd>: show key contents on the right panel
 - <kbd>d</kbd>: delete key
 - <kbd>y</kbd>: copies the contents displayed on the right panel to the clipboard

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,19 @@
+# isort:skip_file
+
 import mem
 from ui import MainUI
 import logging
 from sys import argv
 
-logging.basicConfig(filename='log.txt',level=logging.DEBUG,format='%(asctime)s %(message)s')
+logging.basicConfig(filename='log.txt', level=logging.DEBUG, format='%(asctime)s %(message)s')
 
 client = mem.connect(argv[1], int(argv[2]))
 
 if __name__ == '__main__':
     ui = MainUI()
     ui.refresh_items = lambda: client.get_all_keys()
+    ui.flush_items = lambda: client.flush_all()
     ui.get_item = lambda k: client.get(k)
     ui.del_item = lambda k: client.delete(k)
 
     ui.start()
-
-


### PR DESCRIPTION
Been working with Celery/Memcached stuff recently, and figured out that it would be good if I could check the contents of Memcached. Hence, found your project. Just thought of adding support for flushing/clearing all items since `pymemcache` and Memcached have support for it. Likewise, `flush_all` is handy alternative to restarting Memcached just to clear its contents.

Bound the hotkey to `f` for `flush`, which will also clear all the UI items, both in the left/right panes (i.e. items in key/content panels). Tested to be working in various scenarios, and preserving the current behaviors.
 
PS: Thanks for this useful project. :)